### PR TITLE
Update curve_eval.py

### DIFF
--- a/NURBSDiff/curve_eval.py
+++ b/NURBSDiff/curve_eval.py
@@ -42,8 +42,14 @@ class CurveEval(torch.nn.Module):
         self.curve_param = torch.linspace(0.0, 1.0, steps=out_dim, dtype=torch.float32)
         self.method = method
         self.curve_parameter_span_cpu, self.new_curve_param_cpu = cpp_pre_compute_basis(self.curve_param, self.knot_vectors, num_control_points, order, out_dim, self._dimension)
-        self.curve_parameter_span_cuda, self.new_curve_param_cuda = pre_compute_basis(self.curve_param.cuda(), self.knot_vectors.cuda(), num_control_points, order, out_dim, self._dimension)
+        # --- Induces illegal memory access issues when called repeatedly without kernel restart ---
+        # todo: fix CPP code in `pre_compute_bases`
+        #self.curve_parameter_span_cuda, self.new_curve_param_cuda = pre_compute_basis(self.curve_param.cuda(), self.knot_vectors.cuda(), num_control_points, order, out_dim, self._dimension)
 
+        # --- Move the pre-computed parameters from cpu to gpu ---
+        self.curve_parameter_span_cuda = self.curve_parameter_span_cpu.cuda()
+        self.new_curve_param_cuda = self.new_curve_param_cpu.cuda()
+                     
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Forward pass of the module.
 


### PR DESCRIPTION
Workaround for "illegal memory access" issue that occurs with repeated calls to CurveEval without kernel restart.

**Problem observed:** Making multiple calls to the CurveEval init block without restarting the kernel (i.e., what we do for running the testing scripts), results in an illegal `CUDA error: an illegal memory access was encountered` consistently after each set of 87 iterations. Previously we have used bash scripts to restart the kernel with a new call to the testing script to get around this issue.

**Resolution**
Eliminate the call to the gpu variant and move cpu results to gpu instead.

**What does this mean?**
This fix allows for complete test set evaluation without a need for restarting the kernel and does not reduce performance and/or increase overall compute time meaningfully. In fact, because BOTH cpu and gpu variants were being called previously, independent of the actual device, eliminating the call to the GPU variant and moving the result from CPU to GPU actually appears a bit faster (19.2 sec avg time for curve fitting with IMA issue, vs 18.3 sec with cpu->gpu resolution)